### PR TITLE
sanitize appdir variable in case it's coming from a windows environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,9 @@
-module.exports = ({appdir}) => {
+module.exports = ({appdir: originalAppDir = ''}) => {
+
+  // if the kernel is instantiated in a windows environment, the appdir will contain backslashes
+  // correct this by replacing all backslashes with forward slashes
+  const appdir = originalAppDir.replace(/\\/g, '/');
+
   const fs = require('fs');
   const path = require('path');
   const glob = require('glob');


### PR DESCRIPTION
I'm pretty sure that we can use the modified `appdir` everywhere, @dchapkine. In the few cases where the `appdir` is passed back into the containers, it is often concatenated directly into other paths, which use a standard forward slash, so it makes sense to return the sanitized version. 

For example:

```js
relativeTo: `${this.appdir}/res/mjml-mailer/`
```
in our mailer class